### PR TITLE
Allow setting the kernel release name to overwrite output folder for modules

### DIFF
--- a/elusive/src/cli.rs
+++ b/elusive/src/cli.rs
@@ -46,6 +46,9 @@ pub enum Command {
         /// Path to the kernel module source directory
         #[clap(short, long)]
         modules: Option<PathBuf>,
+        /// Kernel release name to overwrite output folder name for kernel modules
+        #[clap(short, long)]
+        kernel_release: Option<String>,
         /// Path where the initramfs will be written
         #[clap(short, long)]
         output: PathBuf,
@@ -103,9 +106,15 @@ pub fn elusive(args: Args) -> Result<()> {
             ucode,
             modules,
             output,
+            kernel_release,
         } => {
             if let Some(config) = config.initramfs {
-                let initramfs = InitramfsBuilder::from_config(config, modules.as_deref())?.build();
+                let initramfs = InitramfsBuilder::from_config(
+                    config,
+                    modules.as_deref(),
+                    kernel_release.as_deref(),
+                )?
+                .build();
 
                 info!("Writing initramfs to: {}", output.display());
                 let write = Output::from_path(output)?;


### PR DESCRIPTION
Currently when we use a custom module folder other then lib/modules like "/my/custom/kernel/build/path" the path will be replicated in the resulting initramfs.

With this PR we can overwrite the output folder to `/lib/modules/<KERNEL_RELEASE>` 